### PR TITLE
Remove MixedLM estimator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "plotly>=6.2.0",
     "ruff>=0.12.2",
     "scipy>=1.15.3",
-    "statsmodels>=0.14.5",
     "tqdm>=4.67.1",
 ]
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -27,9 +27,7 @@ def test_monte_carlo_bias_small() -> None:
         seed=123,
     )
     results = monte_carlo(scn)
-    for method, data in results.items():
-        if method == "mixedlm":
-            continue
+    for data in results.values():
         mean_est = data["sigma"].mean(axis=0)
         assert np.allclose(mean_est, scn.sigma_true, rtol=0.2)
 


### PR DESCRIPTION
## Summary
- drop statsmodels dependency
- remove MixedLM estimator and related code
- adjust Monte Carlo tests

## Testing
- `ruff format src/vce/simulation.py tests/test_simulation.py pyproject.toml`
- `ruff check pyproject.toml src/vce/simulation.py tests/test_simulation.py`
- `pytest --cov=src` *(fails: ImportError: cannot import name 'metrics_to_row')*
- `coverage report` *(no data due to test failure)*

------
https://chatgpt.com/codex/tasks/task_e_686cbda15ab4832b8197e72036e8c7d5